### PR TITLE
Removing KDE telemetry

### DIFF
--- a/dolphin/PKGBUILD
+++ b/dolphin/PKGBUILD
@@ -1,13 +1,13 @@
 pkgname=dolphin+clang
 pkgver=22.04.1
-pkgrel=1
+pkgrel=2
 pkgdesc='KDE File Manager'
 arch=(x86_64)
 url='https://apps.kde.org/dolphin/'
 license=(LGPL)
 provides=('dolphin' "dolphin=${pkgver}")
 conflicts=('dolphin')
-depends=(baloo-widgets knewstuff kio-extras kcmutils kparts kactivities kuserfeedback)
+depends=(baloo-widgets knewstuff kio-extras kcmutils kparts kactivities)
 makedepends=(extra-cmake-modules kdoctools)
 optdepends=('kde-cli-tools: for editing file type options' 'ffmpegthumbs: video thumbnails' 'kdegraphics-thumbnailers: PDF and PS thumbnails'
   'konsole: terminal panel' 'purpose: share context menu')
@@ -47,6 +47,7 @@ build() {
 
   cmake -B build -S dolphin-${pkgver} \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_DISABLE_FIND_PACKAGE_LibKUserFeedback=ON \
     -DBUILD_TESTING=OFF
 
   cmake --build build

--- a/plasma-desktop/PKGBUILD
+++ b/plasma-desktop/PKGBUILD
@@ -1,6 +1,6 @@
 pkgname=plasma-desktop+clang
 pkgver=5.24.5
-pkgrel=1
+pkgrel=2
 pkgdesc='KDE Plasma Desktop'
 arch=(x86_64)
 url='https://kde.org/plasma-desktop/'
@@ -52,6 +52,7 @@ build() {
 
   cmake -B build -S plasma-desktop-${pkgver} \
     -DCMAKE_BUILD_TYPE=Release \
+    -DCMAKE_DISABLE_FIND_PACKAGE_LibKUserFeedback=ON
     -DCMAKE_INSTALL_LIBEXECDIR=lib \
     -DBUILD_TESTING=OFF
 

--- a/plasma-workspace/PKGBUILD
+++ b/plasma-workspace/PKGBUILD
@@ -1,15 +1,15 @@
 pkgbase=plasma-workspace+clang
 pkgname=(plasma-workspace+clang plasma-wayland-session+clang)
 pkgver=5.24.5
-pkgrel=1
+pkgrel=2
 pkgdesc='KDE Plasma Workspace'
 arch=(x86_64)
 url='https://kde.org/plasma-desktop/'
 license=(LGPL)
 depends=(knotifyconfig ksystemstats ktexteditor libqalculate kde-cli-tools appstream-qt
   xorg-xrdb xorg-xsetroot kactivitymanagerd kholidays xorg-xmessage milou prison kwin
-  plasma-integration kpeople kactivities-stats libkscreen kquickcharts kuserfeedback
-  accountsservice kio-extras kio-fuse qt5-tools)
+  plasma-integration kpeople kactivities-stats libkscreen kquickcharts accountsservice
+  kio-extras kio-fuse qt5-tools)
 makedepends=(extra-cmake-modules kdoctools gpsd baloo networkmanager-qt plasma-wayland-protocols kunitconversion kinit)
 groups=(plasma)
 source=(
@@ -49,6 +49,7 @@ build() {
   cmake -B build -S plasma-workspace-${pkgver} \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_LIBEXECDIR=lib \
+    -DCMAKE_DISABLE_FIND_PACKAGE_LibKUserFeedback=ON \
     -DBUILD_TESTING=OFF
 
   cmake --build build


### PR DESCRIPTION
Removes the binding of available KDE packages from telemetry (KUserFeedback). No functionality should be affected. The KDE settings will lose the feedback option, but that's about it. A similar approach is used in Gentoo. You can disable telemetry there, too (https://packages.gentoo.org/useflags/telemetry).

Important: Packages will still be built using telemetry if KUserFeedback is installed in the system. That is, this PR essentially just removes the hard dependency in kuserfeedback